### PR TITLE
Add table for converted volumes

### DIFF
--- a/source/modules/nphprediction/PythonScriptWrapper.py
+++ b/source/modules/nphprediction/PythonScriptWrapper.py
@@ -178,6 +178,8 @@ class PythonScriptWrapper(object):
             bq.update_mex('Uploading Table result')
             self.voltable = self.uploadtableservice(
                 bq, 'source/volumes_unet.csv')
+            self.volconvtable = self.uploadtableservice(
+                bq, 'source/volumes_conv_unet.csv')
             self.predtable = self.uploadtableservice(
                 bq, 'source/predictions.csv')
         except (Exception, ScriptError) as e:
@@ -196,6 +198,7 @@ class PythonScriptWrapper(object):
         ts = time.gmtime()
         ts_str = time.strftime("%Y-%m-%d %H:%M:%S", ts)
         vols = pd.read_csv('source/volumes_unet.csv')
+        volsConv = pd.read_csv('source/volumes_conv_unet.csv')
         preds = pd.read_csv('source/predictions.csv')
         # outputs = predict( bq, log, **self.options.__dict__ )
         #outtable_xml = table_service.store_array(maxMisorient, name='maxMisorientData')
@@ -205,8 +208,9 @@ class PythonScriptWrapper(object):
 		<tag name="Subcortical" type="string" value="%s"/>
 		<tag name="White Matter" type="string" value="%s"/>
 		<tag name="Volumes Table" type="resource" value="%s"/>
+        <tag name="Volumes Converted Table" type="resource" value="%s"/>
 		<tag name="Prediction" type="string" value="%s"/>
-                    </tag>""" % (str(vols.Scan[0]), str(vols.Vent[0]), str(vols.Sub[0]), str(vols.White[0]), self.voltable.get('value'), str(preds.columns[-1]))
+                    </tag>""" % (str(vols.Scan[0]), str(vols.Vent[0]), str(vols.Sub[0]), str(vols.White[0]), self.voltable.get('value'), self.volconvtable.get('value'), str(preds.columns[-1]))
         outputs = [out_imgxml, out_xml]
         log.debug(outputs)
         # save output back to BisQue

--- a/source/modules/nphprediction/source/postUtils.py
+++ b/source/modules/nphprediction/source/postUtils.py
@@ -62,7 +62,7 @@ def get_volumes(BASE, seg_model='unet', save_last=False):
 		volume_conv_csv = os.path.join(BASE, 'volumes_conv_mcv.csv')
 	elif seg_model == 'unet':
 		volume_csv = os.path.join(BASE, 'volumes_unet.csv')
-		volume_conv_csv = os.path.join(BASE, 'volumes__conv_unet.csv')
+		volume_conv_csv = os.path.join(BASE, 'volumes_conv_unet.csv')
 	csv_exists = os.path.exists(volume_csv)
 	if save_last:
 		f = open(volume_csv, 'a')

--- a/source/modules/nphprediction/source/postUtils.py
+++ b/source/modules/nphprediction/source/postUtils.py
@@ -59,16 +59,22 @@ def get_volumes(BASE, seg_model='unet', save_last=False):
 	imnames.sort()
 	if seg_model == 'mcv':
 		volume_csv = os.path.join(BASE, 'volumes_mcv.csv')
+		volume_conv_csv = os.path.join(BASE, 'volumes_conv_mcv.csv')
 	elif seg_model == 'unet':
 		volume_csv = os.path.join(BASE, 'volumes_unet.csv')
+		volume_conv_csv = os.path.join(BASE, 'volumes__conv_unet.csv')
 	csv_exists = os.path.exists(volume_csv)
 	if save_last:
 		f = open(volume_csv, 'a')
+		fConv = open(volume_conv_csv, 'a')
 	else:
 		f = open(volume_csv, 'w')
+		fConv = open(volume_conv_csv, 'w')
 	writer = csv.writer(f)
+	writerConv = csv.writer(fConv)
 	if not csv_exists or not save_last:
 		writer.writerow(['Scan', 'Vent', 'Sub', 'White'])
+		writerConv.writerow(['Scan', 'Vent', 'Sub', 'White'])
 	ventricle_volumes = []
 	sub_volumes = []
 	white_volumes = []
@@ -113,6 +119,7 @@ def get_volumes(BASE, seg_model='unet', save_last=False):
 
 		whole_brain = float(ventricle+subarachnoid+white_matter)
 		writer.writerow([imname_short, str(ventricle), str(subarachnoid), str(white_matter)])
+		writerConv.writerow([imname_short, str(ventricle/vol_per_vox), str(subarachnoid/vol_per_vox), str(white_matter/vol_per_vox)])
 	f.close()
 
 
@@ -162,5 +169,4 @@ def clean_up(BASE):
 		if os.path.exists(name):
 			os.remove(name)
 	
-
 


### PR DESCRIPTION
This commit should create a new table volumes_conv.csv that will store the converted volumes for ventricle, subarachnoid, and white matter. Example input/output is detailed in the table below:
<img width="599" alt="Screen Shot 2022-06-26 at 6 37 09 PM" src="https://user-images.githubusercontent.com/34698996/176548911-250061ba-4788-4cf7-ad71-168728286065.png">
Closes #49 
